### PR TITLE
add URL if GitHub is the provider

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -5,7 +5,9 @@ import { createRestAPIClient } from "https://cdn.skypack.dev/masto";
   * create the mastodon status message from newreleases.io json input 
   */
 function parseRequest(json: object): string {
-  return `There is a new version of\n${json.project}\non ${json.provider}\nversion: ${json.version}`
+  let url = ""
+  if (json.provider === "github") { url = `https://github.com/${json.project}`}
+  return `There is a new version of\n${json.project}\non ${json.provider}\nversion: ${json.version}${url?`\n${url}`:``}`
 }
 
 /**


### PR DESCRIPTION
Hey Helmut, I enjoy the bot, but would value being able to jump straight to the new version on GitHub if I see a toot. So I added a URL. I don't have Deno installed or more significantly I don't have the newreleases.io webhook set up, so can't test this at an integration level, but I can see in the [webhooks](https://newreleases.io/webhooks) docu there's a `project` property that looks like it's the org/repo value needed. Thanks! 
